### PR TITLE
fix(board): 게시글 정보 줄 때 좋아요/싫어요 개수까지 리턴

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,14 +45,6 @@ bootJar {
     dependsOn asciidoctor
     copy {
         from "${asciidoctor.outputDir}"
-        into 'BOOT-INF/classes/static/docs'
-    }
-}
-
-build {
-    dependsOn asciidoctor
-    copy {
-        from "${asciidoctor.outputDir}"
         into 'src/main/resources/static/docs'
     }
 }

--- a/http/board/board.http
+++ b/http/board/board.http
@@ -1,6 +1,6 @@
 POST {{local}}/api/v1/board
 Content-Type: application/json
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjMyMzg4OTQ0LCJleHAiOjE2MzIzODk1NDR9.Ju5xSV4zJ5c5f0zDFpE_5Vo7D8K-DtSzEXkPHp01LfA
+Authorization: Bearer {{TOKEN}}
 
 {
   "petitionId": "600413",
@@ -11,7 +11,7 @@ Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjMyMzg4OTQ0LCJleHAi
 ### 게시글 수정
 POST {{local}}/api/v1/board/update
 Content-Type: application/json
-Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjMyMzg4OTQ0LCJleHAiOjE2MzIzODk1NDR9.Ju5xSV4zJ5c5f0zDFpE_5Vo7D8K-DtSzEXkPHp01LfA
+Authorization: Bearer {{TOKEN}}
 
 {
   "boardId": 1,
@@ -20,19 +20,28 @@ Authorization: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjMyMzg4OTQ0LCJleHAi
 }
 
 ### 게시글 불러오기
-GET {{local}}/api/v1/board/1
+GET {{local}}/api/v1/getBoard/1
 Content-Type: application/json
 
 ### 게시글 리스트 불러오기
-GET {{local}}/api/v1/board/list?search=&page=0
+GET {{local}}/api/v1/getBoard/list?search=&page=0
 Content-Type: application/json
 
 ### 게시글 찬성/반대
 POST {{local}}/api/v1/board/like
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjMyNDY4OTIyLCJleHAiOjE2MzI0Njk1MjJ9.jKnXILgCxST05CjY4x0HTO0Di7W08kPxNRENZDrqWZQ
+Authorization: Bearer {{TOKEN}}
 
 {
   "boardId": 1,
   "boardState": "LIKE"
 }
+
+###
+GET {{local}}/test-token
+
+> {%
+client.global.set('TOKEN', response.body.data.token)
+client.log(client.global.get('TOKEN'));
+ %}
+

--- a/src/main/java/com/example/nationalpetition/controller/board/BoardController.java
+++ b/src/main/java/com/example/nationalpetition/controller/board/BoardController.java
@@ -6,7 +6,7 @@ import com.example.nationalpetition.dto.board.request.BoardLikeRequest;
 import com.example.nationalpetition.dto.board.request.CreateBoardRequest;
 import com.example.nationalpetition.dto.board.request.DeleteBoardLikeRequest;
 import com.example.nationalpetition.dto.board.request.UpdateBoardRequest;
-import com.example.nationalpetition.dto.board.response.BoardInfoResponse;
+import com.example.nationalpetition.dto.board.response.BoardInfoResponseWithLikeCount;
 import com.example.nationalpetition.service.board.BoardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -25,22 +25,22 @@ public class BoardController {
     private final BoardService boardService;
 
 	@PostMapping("/api/v1/board")
-	public ApiResponse<BoardInfoResponse> createBoard(@RequestBody @Valid CreateBoardRequest request, @MemberId Long memberId) {
+	public ApiResponse<BoardInfoResponseWithLikeCount> createBoard(@RequestBody @Valid CreateBoardRequest request, @MemberId Long memberId) {
 		return ApiResponse.success(boardService.createBoard(request, memberId));
 	}
 
 	@PostMapping("/api/v1/board/update")
-	public ApiResponse<BoardInfoResponse> updateBoard(@RequestBody @Valid UpdateBoardRequest request, @MemberId Long memberId) {
+	public ApiResponse<BoardInfoResponseWithLikeCount> updateBoard(@RequestBody @Valid UpdateBoardRequest request, @MemberId Long memberId) {
 		return ApiResponse.success(boardService.updateBoard(request, memberId));
 	}
 
-	@GetMapping("/api/v1/board/{boardId}")
-	public ApiResponse<BoardInfoResponse> getBoard(@PathVariable Long boardId) {
+	@GetMapping("/api/v1/getBoard/{boardId}")
+	public ApiResponse<BoardInfoResponseWithLikeCount> getBoard(@PathVariable Long boardId) {
 		return ApiResponse.success(boardService.getBoard(boardId));
 	}
 
-	@GetMapping("/api/v1/board/list")
-	public ApiResponse<List<BoardInfoResponse>> retrieveBoard(String search, @PageableDefault(size = 10, sort = "id", direction = DESC) Pageable pageable) {
+	@GetMapping("/api/v1/getBoard/list")
+	public ApiResponse<List<BoardInfoResponseWithLikeCount>> retrieveBoard(String search, @PageableDefault(size = 10, sort = "id", direction = DESC) Pageable pageable) {
 		return ApiResponse.success(boardService.retrieveBoard(search, pageable));
 	}
 

--- a/src/main/java/com/example/nationalpetition/domain/board/repository/BoardLikeRepositoryCustom.java
+++ b/src/main/java/com/example/nationalpetition/domain/board/repository/BoardLikeRepositoryCustom.java
@@ -1,11 +1,14 @@
 package com.example.nationalpetition.domain.board.repository;
 
 import com.example.nationalpetition.domain.board.BoardLike;
+import com.example.nationalpetition.dto.board.response.BoardLikeAndUnLikeCounts;
 
 import java.util.Optional;
 
 public interface BoardLikeRepositoryCustom {
 
     BoardLike findByBoardIdAndMemberId(Long boardId, Long memberId);
+
+    Optional<BoardLikeAndUnLikeCounts> countLikeByBoardId(Long boardId);
 
 }

--- a/src/main/java/com/example/nationalpetition/domain/board/repository/BoardLikeRepositoryCustomImpl.java
+++ b/src/main/java/com/example/nationalpetition/domain/board/repository/BoardLikeRepositoryCustomImpl.java
@@ -1,8 +1,15 @@
 package com.example.nationalpetition.domain.board.repository;
 
 import com.example.nationalpetition.domain.board.BoardLike;
+import com.example.nationalpetition.domain.board.BoardState;
+import com.example.nationalpetition.dto.board.response.BoardLikeAndUnLikeCounts;
+import com.example.nationalpetition.dto.board.response.QBoardLikeAndUnLikeCounts;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
 
 import static com.example.nationalpetition.domain.board.QBoardLike.boardLike;
 
@@ -21,4 +28,18 @@ public class BoardLikeRepositoryCustomImpl implements BoardLikeRepositoryCustom 
                 .fetchOne();
 
     }
+
+    @Override
+    public Optional<BoardLikeAndUnLikeCounts> countLikeByBoardId(Long boardId) {
+        return Optional.ofNullable(queryFactory.select(new QBoardLikeAndUnLikeCounts(
+                        new CaseBuilder().when(boardLike.boardState.eq(BoardState.LIKE)).then(1).otherwise(0).as("boardLikeCounts"),
+                        new CaseBuilder().when(boardLike.boardState.eq(BoardState.UNLIKE)).then(1).otherwise(0).as("boardUnLikeCounts")
+                ))
+                .from(boardLike)
+                .where(
+                        boardLike.boardId.eq(boardId)
+                )
+                .fetchOne());
+    }
+
 }

--- a/src/main/java/com/example/nationalpetition/dto/board/response/BoardInfoResponseWithLikeCount.java
+++ b/src/main/java/com/example/nationalpetition/dto/board/response/BoardInfoResponseWithLikeCount.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class BoardInfoResponse {
+public class BoardInfoResponseWithLikeCount {
 
     private Long boardId;
     private Long memberId;
@@ -18,9 +18,11 @@ public class BoardInfoResponse {
     private String petitionUrl;
     private String petitionsCount;
     private String category;
+    private int boardLikeCounts;
+    private int boardUnLikeCounts;
 
     @Builder
-    public BoardInfoResponse(Long boardId, Long memberId, String petitionTitle, String title, String petitionContent, String content, String petitionUrl, String petitionsCount, String category) {
+    public BoardInfoResponseWithLikeCount(Long boardId, Long memberId, String petitionTitle, String title, String petitionContent, String content, String petitionUrl, String petitionsCount, String category, int boardLikeCounts, int boardUnLikeCounts) {
         this.boardId = boardId;
         this.memberId = memberId;
         this.petitionTitle = petitionTitle;
@@ -30,10 +32,12 @@ public class BoardInfoResponse {
         this.petitionUrl = petitionUrl;
         this.petitionsCount = petitionsCount;
         this.category = category;
+        this.boardLikeCounts = boardLikeCounts;
+        this.boardUnLikeCounts = boardUnLikeCounts;
     }
 
-    public static BoardInfoResponse of(Board board) {
-        return BoardInfoResponse.builder()
+    public static BoardInfoResponseWithLikeCount of(Board board, BoardLikeAndUnLikeCounts boardLikeAndUnLikeCounts) {
+        return BoardInfoResponseWithLikeCount.builder()
                 .boardId(board.getId())
                 .memberId(board.getMemberId())
                 .petitionTitle(board.getPetitionTitle())
@@ -43,6 +47,8 @@ public class BoardInfoResponse {
                 .petitionUrl(board.getPetitionUrl())
                 .petitionsCount(board.getPetitionsCount())
                 .category(board.getCategory())
+                .boardLikeCounts(boardLikeAndUnLikeCounts.getBoardLikeCounts())
+                .boardUnLikeCounts(boardLikeAndUnLikeCounts.getBoardUnLikeCounts())
                 .build();
     }
 

--- a/src/main/java/com/example/nationalpetition/dto/board/response/BoardLikeAndUnLikeCounts.java
+++ b/src/main/java/com/example/nationalpetition/dto/board/response/BoardLikeAndUnLikeCounts.java
@@ -1,0 +1,30 @@
+package com.example.nationalpetition.dto.board.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor
+public class BoardLikeAndUnLikeCounts {
+
+    private int boardLikeCounts;
+
+    private int boardUnLikeCounts;
+
+    @QueryProjection
+    public BoardLikeAndUnLikeCounts(int boardLikeCounts, int boardUnLikeCounts) {
+        this.boardLikeCounts = boardLikeCounts;
+        this.boardUnLikeCounts = boardUnLikeCounts;
+    }
+
+    public static BoardLikeAndUnLikeCounts of(int boardLikeCounts, int boardUnLikeCounts) {
+        return new BoardLikeAndUnLikeCounts(boardLikeCounts, boardUnLikeCounts);
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/nationalpetition/service/board/BoardService.java
+++ b/src/main/java/com/example/nationalpetition/service/board/BoardService.java
@@ -6,9 +6,9 @@ import com.example.nationalpetition.domain.board.repository.BoardLikeRepository;
 import com.example.nationalpetition.domain.board.repository.BoardRepository;
 import com.example.nationalpetition.dto.board.request.BoardLikeRequest;
 import com.example.nationalpetition.dto.board.request.CreateBoardRequest;
-import com.example.nationalpetition.dto.board.request.DeleteBoardLikeRequest;
 import com.example.nationalpetition.dto.board.request.UpdateBoardRequest;
-import com.example.nationalpetition.dto.board.response.BoardInfoResponse;
+import com.example.nationalpetition.dto.board.response.BoardInfoResponseWithLikeCount;
+import com.example.nationalpetition.dto.board.response.BoardLikeAndUnLikeCounts;
 import com.example.nationalpetition.external.petition.PetitionClient;
 import com.example.nationalpetition.external.petition.dto.response.PetitionResponse;
 import com.example.nationalpetition.utils.error.ErrorCode;
@@ -30,31 +30,37 @@ public class BoardService {
     private final PetitionClient petitionClient;
 
     @Transactional
-    public BoardInfoResponse createBoard(CreateBoardRequest request, Long memberId) {
+    public BoardInfoResponseWithLikeCount createBoard(CreateBoardRequest request, Long memberId) {
         PetitionResponse petitionInfo = petitionClient.getPetitionInfo(request.getPetitionId());
         final Board board = boardRepository.save(request.toEntity(petitionInfo, memberId));
-        return BoardInfoResponse.of(board);
+        return BoardInfoResponseWithLikeCount.of(board, BoardLikeAndUnLikeCounts.of(0, 0));
     }
 
     @Transactional
-    public BoardInfoResponse updateBoard(UpdateBoardRequest request, Long memberId) {
+    public BoardInfoResponseWithLikeCount updateBoard(UpdateBoardRequest request, Long memberId) {
         Board board = boardRepository.findByIdAndMemberId(request.getBoardId(), memberId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXCEPTION_BOARD));
         board.updateBoard(request.getTitle(), request.getContent());
-        return BoardInfoResponse.of(board);
+        BoardLikeAndUnLikeCounts boardLikeAndUnLikeCounts = boardLikeRepository.countLikeByBoardId(board.getId())
+                .orElse(BoardLikeAndUnLikeCounts.of(0, 0));
+        return BoardInfoResponseWithLikeCount.of(board, boardLikeAndUnLikeCounts);
     }
 
     @Transactional(readOnly = true)
-    public BoardInfoResponse getBoard(Long boardId) {
+    public BoardInfoResponseWithLikeCount getBoard(Long boardId) {
         final Board board = boardRepository.findByIdAndIsDeletedFalse(boardId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXCEPTION_BOARD));
-        return BoardInfoResponse.of(board);
+        BoardLikeAndUnLikeCounts boardLikeAndUnLikeCounts = boardLikeRepository.countLikeByBoardId(board.getId())
+                .orElse(BoardLikeAndUnLikeCounts.of(0, 0));
+        return BoardInfoResponseWithLikeCount.of(board, boardLikeAndUnLikeCounts);
     }
 
     @Transactional(readOnly = true)
-    public List<BoardInfoResponse> retrieveBoard(String search, Pageable pageable) {
+    public List<BoardInfoResponseWithLikeCount> retrieveBoard(String search, Pageable pageable) {
         return boardRepository.findByTitleContaining(search, pageable)
-                .stream().map(BoardInfoResponse::of).collect(Collectors.toList());
+                .stream().map(board -> BoardInfoResponseWithLikeCount.of(board, boardLikeRepository.countLikeByBoardId(board.getId())
+                        .orElse(BoardLikeAndUnLikeCounts.of(0, 0))))
+                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/test/java/com/example/nationalpetition/controller/board/BoardControllerTest.java
+++ b/src/test/java/com/example/nationalpetition/controller/board/BoardControllerTest.java
@@ -102,7 +102,9 @@ public class BoardControllerTest {
                                 fieldWithPath("data.content").description("내가 작성한 글"),
                                 fieldWithPath("data.petitionUrl").description("url"),
                                 fieldWithPath("data.petitionsCount").description("청원 수"),
-                                fieldWithPath("data.category").description("청원 카테고리")
+                                fieldWithPath("data.category").description("청원 카테고리"),
+                                fieldWithPath("data.boardLikeCounts").description("좋아요 개수"),
+                                fieldWithPath("data.boardUnLikeCounts").description("싫어요 개수")
                         )
                 ));
         resultActions.andExpect(status().isOk());
@@ -148,7 +150,9 @@ public class BoardControllerTest {
                                 fieldWithPath("data.content").description("내가 작성한 글"),
                                 fieldWithPath("data.petitionUrl").description("url"),
                                 fieldWithPath("data.petitionsCount").description("청원 수"),
-                                fieldWithPath("data.category").description("청원 카테고리")
+                                fieldWithPath("data.category").description("청원 카테고리"),
+                                fieldWithPath("data.boardLikeCounts").description("좋아요 개수"),
+                                fieldWithPath("data.boardUnLikeCounts").description("싫어요 개수")
                         )
                 ));
         resultActions.andExpect(status().isOk());
@@ -165,8 +169,7 @@ public class BoardControllerTest {
 
         // when & then
         final ResultActions resultActions = mockMvc.perform(
-                RestDocumentationRequestBuilders.get("/api/v1/board/{id}", board.getId())
-                        .header("Authorization", "Bearer ".concat(token.getToken()))
+                RestDocumentationRequestBuilders.get("/api/v1/getBoard/{id}", board.getId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
@@ -187,7 +190,9 @@ public class BoardControllerTest {
                                 fieldWithPath("data.content").description("내가 작성한 글"),
                                 fieldWithPath("data.petitionUrl").description("url"),
                                 fieldWithPath("data.petitionsCount").description("청원 수"),
-                                fieldWithPath("data.category").description("청원 카테고리")
+                                fieldWithPath("data.category").description("청원 카테고리"),
+                                fieldWithPath("data.boardLikeCounts").description("좋아요 개수"),
+                                fieldWithPath("data.boardUnLikeCounts").description("싫어요 개수")
                         )
                 ));
         resultActions.andExpect(status().isOk());
@@ -204,8 +209,7 @@ public class BoardControllerTest {
 
         // when & then
         final ResultActions resultActions = mockMvc.perform(
-                RestDocumentationRequestBuilders.get("/api/v1/board/list?search=&page=0&size=10")
-                        .header("Authorization", "Bearer ".concat(token.getToken()))
+                RestDocumentationRequestBuilders.get("/api/v1/getBoard/list?search=&page=0&size=10")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
@@ -228,7 +232,9 @@ public class BoardControllerTest {
                                 fieldWithPath("data[].content").description("내가 작성한 글"),
                                 fieldWithPath("data[].petitionUrl").description("url"),
                                 fieldWithPath("data[].petitionsCount").description("청원 수"),
-                                fieldWithPath("data[].category").description("청원 카테고리")
+                                fieldWithPath("data[].category").description("청원 카테고리"),
+                                fieldWithPath("data[].boardLikeCounts").description("좋아요 개수"),
+                                fieldWithPath("data[].boardUnLikeCounts").description("싫어요 개수")
                         )
                 ));
         resultActions.andExpect(status().isOk());

--- a/src/test/java/com/example/nationalpetition/service/board/BoardServiceTest.java
+++ b/src/test/java/com/example/nationalpetition/service/board/BoardServiceTest.java
@@ -8,7 +8,7 @@ import com.example.nationalpetition.domain.board.repository.BoardRepository;
 import com.example.nationalpetition.dto.board.request.BoardLikeRequest;
 import com.example.nationalpetition.dto.board.request.CreateBoardRequest;
 import com.example.nationalpetition.dto.board.request.UpdateBoardRequest;
-import com.example.nationalpetition.dto.board.response.BoardInfoResponse;
+import com.example.nationalpetition.dto.board.response.BoardInfoResponseWithLikeCount;
 import com.example.nationalpetition.testObject.BoardCreator;
 import com.example.nationalpetition.testObject.BoardLikeCreator;
 import com.example.nationalpetition.utils.error.exception.NotFoundException;
@@ -74,7 +74,7 @@ public class BoardServiceTest {
         CreateBoardRequest request = CreateBoardRequest.testInstance(600413L, "title", "content");
 
         // when
-        final BoardInfoResponse response = boardService.createBoard(request, 1L);
+        final BoardInfoResponseWithLikeCount response = boardService.createBoard(request, 1L);
 
         // then
         final List<Board> boardList = boardRepository.findAll();
@@ -131,6 +131,23 @@ public class BoardServiceTest {
         assertThat(boardList.get(0).getContent()).isEqualTo(board.getContent());
     }
 
+    @DisplayName("게시글 아이디로 게시글을 불러올 때 좋아요 개수도 가져온다")
+    @Test
+    void 게시글_불러오기2() {
+        // given
+        Board board = new Board(1L, "petitionTitle", "title", "petitionContent", "content", "url", "10000", "사회문제");
+        boardRepository.save(board);
+
+        // when
+        boardService.getBoard(board.getId());
+
+        // then
+        final List<Board> boardList = boardRepository.findAll();
+        assertThat(boardList).hasSize(1);
+        assertThat(boardList.get(0).getTitle()).isEqualTo(board.getTitle());
+        assertThat(boardList.get(0).getContent()).isEqualTo(board.getContent());
+    }
+
     @DisplayName("title 기준으로 검색하고 기본 10개씩 첫페이지는 0으로 가져온다.")
     @Test
     void 게시글_리스트_불러오기() {
@@ -139,7 +156,7 @@ public class BoardServiceTest {
 
         // when
         final Pageable pageable = PageRequest.of(0, 10, DESC, "id");
-        final List<BoardInfoResponse> responseList = boardService.retrieveBoard("", pageable);
+        final List<BoardInfoResponseWithLikeCount> responseList = boardService.retrieveBoard("", pageable);
 
         // then
         final List<Board> boardList = boardRepository.findAll();
@@ -156,7 +173,7 @@ public class BoardServiceTest {
 
         // when
         final Pageable pageable = PageRequest.of(0, 10, DESC, "id");
-        final List<BoardInfoResponse> responseList = boardService.retrieveBoard("1", pageable);
+        final List<BoardInfoResponseWithLikeCount> responseList = boardService.retrieveBoard("1", pageable);
 
         // then
         final List<Board> boardList = boardRepository.findAll();
@@ -174,7 +191,7 @@ public class BoardServiceTest {
 
         // when
         final Pageable pageable = PageRequest.of(1, 10, DESC, "id");
-        final List<BoardInfoResponse> responseList = boardService.retrieveBoard("1", pageable);
+        final List<BoardInfoResponseWithLikeCount> responseList = boardService.retrieveBoard("1", pageable);
 
         // then
         assertThat(responseList).isEmpty();


### PR DESCRIPTION
게시글의 좋아요 싫어요 개수까지 리턴.  게시글 리스트 보여줄 때 이렇게 하면 데이터가 많아지면 쿼리 너무 많이 날려서 별로인가?