### PR TITLE
fix(bac-38) : 닉네임 등록 후 response 값 수정 및 토큰 시간 30분으로 연장

### DIFF
--- a/src/main/java/com/example/nationalpetition/controller/member/MemberController.java
+++ b/src/main/java/com/example/nationalpetition/controller/member/MemberController.java
@@ -7,6 +7,7 @@ import com.example.nationalpetition.dto.member.request.NickNameRequest;
 import com.example.nationalpetition.dto.member.response.MemberResponse;
 import com.example.nationalpetition.security.oauth2.OAuth2Dto;
 import com.example.nationalpetition.service.member.MemberService;
+import com.example.nationalpetition.utils.message.MessageType;
 import com.example.nationalpetition.utils.ValidationUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -45,7 +46,7 @@ public class MemberController {
 
 	@Operation(summary = "닉네임을 등록하는 API", security = {@SecurityRequirement(name = "BearerKey")})
 	@PostMapping("/api/v1/mypage/nickName")
-	public ApiResponse<String> addNickName(@MemberId Long memberId,
+	public ApiResponse<MessageType> addNickName(@MemberId Long memberId,
 												   @RequestBody @Valid NickNameRequest request, BindingResult bindingResult) throws BindException {
 		ValidationUtils.validateBindingResult(bindingResult);
 		return ApiResponse.success(memberService.addNickName(memberId, request));
@@ -60,7 +61,7 @@ public class MemberController {
 
 	@Operation(summary = "회원을 탈퇴하는 API", security = {@SecurityRequirement(name = "BearerKey")})
 	@DeleteMapping("/api/v1/mypage/delete")
-	public ApiResponse<String> deleteMember(@MemberId Long memberId) {
+	public ApiResponse<MessageType> deleteMember(@MemberId Long memberId) {
 		return ApiResponse.success(memberService.deleteMember(memberId));
 	}
 

--- a/src/main/java/com/example/nationalpetition/controller/member/MemberController.java
+++ b/src/main/java/com/example/nationalpetition/controller/member/MemberController.java
@@ -45,7 +45,7 @@ public class MemberController {
 
 	@Operation(summary = "닉네임을 등록하는 API", security = {@SecurityRequirement(name = "BearerKey")})
 	@PostMapping("/api/v1/mypage/nickName")
-	public ApiResponse<MemberResponse> addNickName(@MemberId Long memberId,
+	public ApiResponse<String> addNickName(@MemberId Long memberId,
 												   @RequestBody @Valid NickNameRequest request, BindingResult bindingResult) throws BindException {
 		ValidationUtils.validateBindingResult(bindingResult);
 		return ApiResponse.success(memberService.addNickName(memberId, request));

--- a/src/main/java/com/example/nationalpetition/dto/member/MessageConst.java
+++ b/src/main/java/com/example/nationalpetition/dto/member/MessageConst.java
@@ -1,5 +1,7 @@
 package com.example.nationalpetition.dto.member;
 
-public interface DeleteMessageConst {
+public interface MessageConst {
     public static final String MESSAGE = "회원 탈퇴가 정상적으로 처리되었습니다.";
+    String DUPLICATE = "duplicate";
+    String SUCCESS = "success";
 }

--- a/src/main/java/com/example/nationalpetition/dto/member/MessageConst.java
+++ b/src/main/java/com/example/nationalpetition/dto/member/MessageConst.java
@@ -1,7 +1,0 @@
-package com.example.nationalpetition.dto.member;
-
-public interface MessageConst {
-    public static final String MESSAGE = "회원 탈퇴가 정상적으로 처리되었습니다.";
-    String DUPLICATE = "duplicate";
-    String SUCCESS = "success";
-}

--- a/src/main/java/com/example/nationalpetition/security/jwt/TokenService.java
+++ b/src/main/java/com/example/nationalpetition/security/jwt/TokenService.java
@@ -24,8 +24,8 @@ public class TokenService {
 	}
 
 	public Token generateToken(Long memberId) {
-		// 토큰 인증시간 = 10분, refresh 토큰 만료 시간 = 3주
-		final long tokenPeriod = 1000L * 60L * 10L;
+		// 토큰 인증시간 = 30분, refresh 토큰 만료 시간 = 3주
+		final long tokenPeriod = 1000L * 60L * 30L;
 		final long refreshPeriod = 1000L * 60L * 60L * 24L * 30L * 3L;
 
 		final Claims claims = Jwts.claims().setSubject(String.valueOf(memberId));

--- a/src/main/java/com/example/nationalpetition/service/member/MemberService.java
+++ b/src/main/java/com/example/nationalpetition/service/member/MemberService.java
@@ -4,6 +4,7 @@ import com.example.nationalpetition.domain.member.entity.Member;
 import com.example.nationalpetition.dto.board.response.BoardInfoResponseInMyPage;
 import com.example.nationalpetition.dto.member.request.NickNameRequest;
 import com.example.nationalpetition.dto.member.response.MemberResponse;
+import com.example.nationalpetition.utils.message.MessageType;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -13,9 +14,9 @@ public interface MemberService {
 
     Member findByEmail(String email);
 
-    String addNickName(Long memberId, NickNameRequest request);
+    MessageType addNickName(Long memberId, NickNameRequest request);
 
-    String deleteMember(Long memberId);
+    MessageType deleteMember(Long memberId);
 
     List<BoardInfoResponseInMyPage> getMyBoardList(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/example/nationalpetition/service/member/MemberService.java
+++ b/src/main/java/com/example/nationalpetition/service/member/MemberService.java
@@ -13,7 +13,7 @@ public interface MemberService {
 
     Member findByEmail(String email);
 
-    MemberResponse addNickName(Long memberId, NickNameRequest request);
+    String addNickName(Long memberId, NickNameRequest request);
 
     String deleteMember(Long memberId);
 

--- a/src/main/java/com/example/nationalpetition/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/nationalpetition/service/member/MemberServiceImpl.java
@@ -9,7 +9,7 @@ import com.example.nationalpetition.domain.member.repository.DeleteMemberReposit
 import com.example.nationalpetition.domain.member.repository.MemberRepository;
 import com.example.nationalpetition.dto.board.response.BoardInfoResponseInMyPage;
 import com.example.nationalpetition.dto.board.response.BoardLikeAndUnLikeCounts;
-import com.example.nationalpetition.dto.member.DeleteMessageConst;
+import com.example.nationalpetition.dto.member.MessageConst;
 import com.example.nationalpetition.dto.member.request.NickNameRequest;
 import com.example.nationalpetition.dto.member.response.MemberResponse;
 import com.example.nationalpetition.utils.error.exception.NotFoundException;
@@ -48,11 +48,13 @@ public class MemberServiceImpl implements MemberService {
 
     @Transactional
     @Override
-    public MemberResponse addNickName(Long memberId, NickNameRequest request) {
-        MemberServiceUtils.duplicateNickName(memberRepository, request.getNickName());
+    public String addNickName(Long memberId, NickNameRequest request) {
+        if (memberRepository.duplicateNickName(request.getNickName())) {
+            return MessageConst.DUPLICATE;
+        }
         final Member member = MemberServiceUtils.isAlreadyExistNickName(memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXCEPTION_USER)));
         member.addNickName(request.getNickName());
-        return MemberResponse.of(memberRepository.save(member));
+        return MessageConst.SUCCESS;
     }
 
     // TODO : 순조가 댓글개수 가져오는 기능 추가하면 commentRepository 에서 조회수 찾아오는거 수정하기
@@ -72,7 +74,7 @@ public class MemberServiceImpl implements MemberService {
         final DeleteMember deleteMember = DeleteMember.of(member);
         deleteMemberRepository.save(deleteMember);
         memberRepository.delete(member);
-        return DeleteMessageConst.MESSAGE;
+        return MessageConst.MESSAGE;
     }
 
 }

--- a/src/main/java/com/example/nationalpetition/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/nationalpetition/service/member/MemberServiceImpl.java
@@ -9,9 +9,9 @@ import com.example.nationalpetition.domain.member.repository.DeleteMemberReposit
 import com.example.nationalpetition.domain.member.repository.MemberRepository;
 import com.example.nationalpetition.dto.board.response.BoardInfoResponseInMyPage;
 import com.example.nationalpetition.dto.board.response.BoardLikeAndUnLikeCounts;
-import com.example.nationalpetition.dto.member.MessageConst;
 import com.example.nationalpetition.dto.member.request.NickNameRequest;
 import com.example.nationalpetition.dto.member.response.MemberResponse;
+import com.example.nationalpetition.utils.message.MessageType;
 import com.example.nationalpetition.utils.error.exception.NotFoundException;
 import com.example.nationalpetition.utils.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -48,13 +48,13 @@ public class MemberServiceImpl implements MemberService {
 
     @Transactional
     @Override
-    public String addNickName(Long memberId, NickNameRequest request) {
+    public MessageType addNickName(Long memberId, NickNameRequest request) {
         if (memberRepository.duplicateNickName(request.getNickName())) {
-            return MessageConst.DUPLICATE;
+            return MessageType.NICKNAME_DUPLICATE;
         }
         final Member member = MemberServiceUtils.isAlreadyExistNickName(memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXCEPTION_USER)));
         member.addNickName(request.getNickName());
-        return MessageConst.SUCCESS;
+        return MessageType.NICKNAME_SUCCESS;
     }
 
     // TODO : 순조가 댓글개수 가져오는 기능 추가하면 commentRepository 에서 조회수 찾아오는거 수정하기
@@ -69,12 +69,12 @@ public class MemberServiceImpl implements MemberService {
 
     @Transactional
     @Override
-    public String deleteMember(Long memberId) {
+    public MessageType deleteMember(Long memberId) {
         final Member member = memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EXCEPTION_USER));
         final DeleteMember deleteMember = DeleteMember.of(member);
         deleteMemberRepository.save(deleteMember);
         memberRepository.delete(member);
-        return MessageConst.MESSAGE;
+        return MessageType.DELETE_MEMBER;
     }
 
 }

--- a/src/main/java/com/example/nationalpetition/utils/message/MessageType.java
+++ b/src/main/java/com/example/nationalpetition/utils/message/MessageType.java
@@ -1,0 +1,17 @@
+package com.example.nationalpetition.utils.message;
+
+import lombok.Getter;
+
+@Getter
+public enum MessageType {
+
+    DELETE_MEMBER("회원 탈퇴가 정상적으로 처리되었습니다."),
+    NICKNAME_DUPLICATE("duplicate"),
+    NICKNAME_SUCCESS("success");
+
+    private final String message;
+
+    MessageType(String message) {
+        this.message = message;
+    }
+}

--- a/src/test/java/com/example/nationalpetition/controller/member/MemberControllerTest.java
+++ b/src/test/java/com/example/nationalpetition/controller/member/MemberControllerTest.java
@@ -128,10 +128,8 @@ class MemberControllerTest {
 						responseFields(
 								fieldWithPath("code").type(JsonFieldType.STRING).description("code"),
 								fieldWithPath("message").type(JsonFieldType.STRING).description("message"),
-								fieldWithPath("data.name").type(JsonFieldType.STRING).description("이름"),
-								fieldWithPath("data.email").type(JsonFieldType.STRING).description("이메일"),
-								fieldWithPath("data.picture").type(JsonFieldType.STRING).description("프로필사진"),
-								fieldWithPath("data.nickName").type(JsonFieldType.STRING).description("닉네임")
+								fieldWithPath("data").type(JsonFieldType.STRING).description("data")
+
 						)
 				)
 			);
@@ -155,11 +153,16 @@ class MemberControllerTest {
 						.contentType(MediaType.APPLICATION_JSON))
 				.andDo(print())
 				.andDo(document("member/addNickName/Duplicate",
-						preprocessResponse(prettyPrint())))
-				.andExpect(result -> assertTrue(result.getResolvedException().getClass().isAssignableFrom(DuplicateException.class)))
-				.andExpect(result -> assertThat(result.getResolvedException().getMessage()).isEqualTo(ErrorCode.DUPLICATE_EXCEPTION_NICKNAME.getMessage()));
+						preprocessResponse(prettyPrint()),
+						responseFields(
+								fieldWithPath("code").type(JsonFieldType.STRING).description("code"),
+								fieldWithPath("message").type(JsonFieldType.STRING).description("message"),
+								fieldWithPath("data").type(JsonFieldType.STRING).description("data")
+						)
+					)
+				);
 		//then
-		resultActions.andExpect(status().isConflict());
+		resultActions.andExpect(status().isOk());
 	}
 
 	@Test

--- a/src/test/java/com/example/nationalpetition/service/member/MemberServiceTest.java
+++ b/src/test/java/com/example/nationalpetition/service/member/MemberServiceTest.java
@@ -6,6 +6,7 @@ import com.example.nationalpetition.domain.board.repository.BoardLikeRepository;
 import com.example.nationalpetition.domain.board.repository.BoardRepository;
 import com.example.nationalpetition.domain.comment.Comment;
 import com.example.nationalpetition.domain.comment.CommentRepository;
+import com.example.nationalpetition.domain.member.entity.DeleteMember;
 import com.example.nationalpetition.domain.member.entity.Member;
 import com.example.nationalpetition.domain.member.repository.DeleteMemberRepository;
 import com.example.nationalpetition.domain.member.repository.MemberRepository;
@@ -122,7 +123,6 @@ public class MemberServiceTest {
         assertThatThrownBy(() -> memberService.addNickName(memberId, request))
                 .isInstanceOf(AlreadyExistException.class)
                 .hasMessage(ErrorCode.ALREADY_EXIST_EXCEPTION_ADD_NICKNAME.getMessage());
-
     }
 
 
@@ -190,7 +190,58 @@ public class MemberServiceTest {
         assertThatThrownBy(() -> memberService.findById(memberId))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessage(ErrorCode.NOT_FOUND_EXCEPTION_USER.getMessage());
+    }
 
+
+    @Test
+    @DisplayName("ID값으로 회원 찾기")
+    void findById() {
+        //given
+        final Long memberId = 회원가입하기();
+        //when
+        final MemberResponse memberResponse = memberService.findById(memberId);
+        //then
+        assertThat(memberResponse.getName()).isEqualTo("이름");
+        assertThat(memberResponse.getNickName()).isEqualTo("닉네임");
+        assertThat(memberResponse.getEmail()).isEqualTo("aa@naver.com");
+    }
+
+    @Test
+    @DisplayName("Id값으로 회원 찾기 - 실패")
+    void findById_fail() {
+        //given
+        final Long memberId = 회원가입하기();
+        //when && then
+        assertThatThrownBy(() -> memberService.findById(memberId + 1L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.NOT_FOUND_EXCEPTION_USER.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("이메일로 회원 찾기")
+    void findByEmail() {
+        //given
+        회원가입하기();
+        final String email = "aa@naver.com";
+        //when
+        final Member member = memberService.findByEmail(email);
+        //then
+        assertThat(member.getName()).isEqualTo("이름");
+        assertThat(member.getNickName()).isEqualTo("닉네임");
+        assertThat(member.getEmail()).isEqualTo("aa@naver.com");
+    }
+
+    @Test
+    @DisplayName("이메일로 회원 찾기 - 실패")
+    void findByEmail_fail() {
+        //given
+        회원가입하기();
+        final String email = "fail@naver.com";
+        //when && then
+        assertThatThrownBy(() -> memberService.findByEmail(email))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage(ErrorCode.NOT_FOUND_EXCEPTION_USER.getMessage());
     }
 
 

--- a/src/test/java/com/example/nationalpetition/service/member/MemberServiceTest.java
+++ b/src/test/java/com/example/nationalpetition/service/member/MemberServiceTest.java
@@ -11,12 +11,11 @@ import com.example.nationalpetition.domain.member.repository.DeleteMemberReposit
 import com.example.nationalpetition.domain.member.repository.MemberRepository;
 import com.example.nationalpetition.dto.board.request.BoardLikeRequest;
 import com.example.nationalpetition.dto.board.response.BoardInfoResponseInMyPage;
-import com.example.nationalpetition.dto.member.MessageConst;
 import com.example.nationalpetition.dto.member.request.NickNameRequest;
 import com.example.nationalpetition.dto.member.response.MemberResponse;
+import com.example.nationalpetition.utils.message.MessageType;
 import com.example.nationalpetition.utils.error.ErrorCode;
 import com.example.nationalpetition.utils.error.exception.AlreadyExistException;
-import com.example.nationalpetition.utils.error.exception.DuplicateException;
 import com.example.nationalpetition.utils.error.exception.NotFoundException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -95,9 +94,9 @@ public class MemberServiceTest {
         final Member member = memberRepository.save(Member.of("이름", "email@email.com", "picture"));
         final NickNameRequest request = new NickNameRequest("닉네임");
         //when
-        final String message = memberService.addNickName(member.getId(), request);
+        final MessageType message = memberService.addNickName(member.getId(), request);
         //then
-        assertThat(message).isEqualTo(MessageConst.SUCCESS);
+        assertThat(message).isEqualTo(MessageType.NICKNAME_SUCCESS);
     }
 
     @Test
@@ -108,9 +107,9 @@ public class MemberServiceTest {
         final Member member = memberRepository.save(Member.of("아아아", "eee@ee.ee", "piiicture"));
         final NickNameRequest request = new NickNameRequest("닉네임");
         //when
-        final String message = memberService.addNickName(member.getId(), request);
+        final MessageType message = memberService.addNickName(member.getId(), request);
         //then
-        assertThat(message).isEqualTo(MessageConst.DUPLICATE);
+        assertThat(message).isEqualTo(MessageType.NICKNAME_DUPLICATE);
     }
 
     @Test
@@ -184,9 +183,9 @@ public class MemberServiceTest {
         //given
         final Long memberId = 회원가입하기();
         //when
-        final String message = memberService.deleteMember(memberId);
+        final MessageType message = memberService.deleteMember(memberId);
         //then
-        assertThat(message).isEqualTo(MessageConst.MESSAGE);
+        assertThat(message).isEqualTo(MessageType.DELETE_MEMBER);
         assertThat(deleteMemberRepository.findAll().size()).isEqualTo(1);
         assertThatThrownBy(() -> memberService.findById(memberId))
                 .isInstanceOf(NotFoundException.class)

--- a/src/test/java/com/example/nationalpetition/service/member/MemberServiceTest.java
+++ b/src/test/java/com/example/nationalpetition/service/member/MemberServiceTest.java
@@ -11,7 +11,7 @@ import com.example.nationalpetition.domain.member.repository.DeleteMemberReposit
 import com.example.nationalpetition.domain.member.repository.MemberRepository;
 import com.example.nationalpetition.dto.board.request.BoardLikeRequest;
 import com.example.nationalpetition.dto.board.response.BoardInfoResponseInMyPage;
-import com.example.nationalpetition.dto.member.DeleteMessageConst;
+import com.example.nationalpetition.dto.member.MessageConst;
 import com.example.nationalpetition.dto.member.request.NickNameRequest;
 import com.example.nationalpetition.dto.member.response.MemberResponse;
 import com.example.nationalpetition.utils.error.ErrorCode;
@@ -27,9 +27,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
 import java.util.List;
 
 
@@ -97,12 +95,9 @@ public class MemberServiceTest {
         final Member member = memberRepository.save(Member.of("이름", "email@email.com", "picture"));
         final NickNameRequest request = new NickNameRequest("닉네임");
         //when
-        final MemberResponse memberResponse = memberService.addNickName(member.getId(), request);
+        final String message = memberService.addNickName(member.getId(), request);
         //then
-        assertThat(memberResponse.getNickName()).isEqualTo("닉네임");
-        assertThat(memberResponse.getName()).isEqualTo("이름");
-        assertThat(memberResponse.getEmail()).isEqualTo("email@email.com");
-        assertThat(memberResponse.getPicture()).isEqualTo("picture");
+        assertThat(message).isEqualTo(MessageConst.SUCCESS);
     }
 
     @Test
@@ -112,10 +107,10 @@ public class MemberServiceTest {
         회원가입하기();
         final Member member = memberRepository.save(Member.of("아아아", "eee@ee.ee", "piiicture"));
         final NickNameRequest request = new NickNameRequest("닉네임");
-        //when && then
-        assertThatThrownBy(() -> memberService.addNickName(member.getId(), request))
-                .isInstanceOf(DuplicateException.class)
-                .hasMessage(ErrorCode.DUPLICATE_EXCEPTION_NICKNAME.getMessage());
+        //when
+        final String message = memberService.addNickName(member.getId(), request);
+        //then
+        assertThat(message).isEqualTo(MessageConst.DUPLICATE);
     }
 
     @Test
@@ -191,7 +186,7 @@ public class MemberServiceTest {
         //when
         final String message = memberService.deleteMember(memberId);
         //then
-        assertThat(message).isEqualTo(DeleteMessageConst.MESSAGE);
+        assertThat(message).isEqualTo(MessageConst.MESSAGE);
         assertThat(deleteMemberRepository.findAll().size()).isEqualTo(1);
         assertThatThrownBy(() -> memberService.findById(memberId))
                 .isInstanceOf(NotFoundException.class)


### PR DESCRIPTION
아 저거 그리고 response값 성공하면 성공 = success, 중복 = duplicate (edited) 
1:26
이렇게 넘겨줄 수 있나요

이렇게 요청이 들어와서 닉네임 중복 시 원래는 예외로 처리했었는데 그냥 200에 메세지 리턴하는걸로 바꿨는데 괜찮을까요? ㅜㅜ